### PR TITLE
Fix build: remove unused imports and resolve TypeScript noUnusedLocals errors

### DIFF
--- a/my-react-app/src/components/SpotifyHeader.tsx
+++ b/my-react-app/src/components/SpotifyHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import SearchBar from './SearchBar';
 
 interface SpotifyHeaderProps {
@@ -11,7 +11,6 @@ const SpotifyHeader: React.FC<SpotifyHeaderProps> = ({
   onToggleSidebar, 
   isSidebarCollapsed = false 
 }) => {
-  const location = useLocation();
   const [showUserMenu, setShowUserMenu] = useState(false);
 
   const navigationButtons = [

--- a/my-react-app/src/layouts/MainLayout.tsx
+++ b/my-react-app/src/layouts/MainLayout.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Outlet, Link, useLocation } from "react-router-dom";
-import SearchBar from "../components/SearchBar";
+import { Outlet, useLocation } from "react-router-dom";
 import MusicPlayer from "../components/MusicPlayer";
 import AddTrackForm from "../components/AddTrackForm";
 import Sidebar from "../components/Sidebar";


### PR DESCRIPTION
Виправлено помилку виконання команди `npm run build` (раніше була невалідна спроба з кореня і помилки TypeScript через невикористані імпорти/змінні). Тепер білд успішно проходить.
- Видалено невикористані імпорти/змінні, що спричиняли TS6133:
 - `src/components/SpotifyHeader.tsx`: прибрано `useLocation`
 - `src/layouts/MainLayout.tsx`: прибрано `Link`, `SearchBar`
- Перевірено білд: `tsc -b && vite build` завершується без помилок
- Оновлено інструкцію запуску білду: з каталогу `my-react-app`